### PR TITLE
MORPHOS: fix makefile.amiga and libpng shared

### DIFF
--- a/src/Makefile.amiga
+++ b/src/Makefile.amiga
@@ -23,8 +23,8 @@ endif
 #endif
 
 #ifeq ($(OSTYPE), MorphOS)
-#CXXFLAGS +=
-#LDFLAGS +=
+CXXFLAGS += -I/usr/local/include -D__MORPHOS_SHAREDLIBS
+LDFLAGS = $(shell sdl-config --libs) -lGL -lGLU -lpng_shared -lz_shared -lopenal -ljpeg_shared
 #endif
 
 .PHONY: all clean
@@ -56,7 +56,7 @@ OPENMRAC_OBJS = \
 	load_texture.o \
 	main.o \
 	matmng.o \
-	menu.o \
+	mainmenu.o \
 	mtrxinv.o \
 	octopus.o \
 	particles.o \

--- a/src/pict2_png.cpp
+++ b/src/pict2_png.cpp
@@ -10,7 +10,11 @@
 
 void user_error_fn(png_structp png_ptr, png_const_charp /*err_str*/)
 {
+#ifdef __MORPHOS__
+	longjmp(png_ptr->jmpbuf59, 1);		
+#else
     longjmp(png_jmpbuf(png_ptr), 1);
+#endif
 }
 
 void user_warning_fn(png_structp, png_const_charp)
@@ -98,7 +102,11 @@ int Pict2::loadpng_pom(bool bfile, const void* fname_data, unsigned int data_siz
     }
 
     /* Error handling - REQUIRED by user error handler */
+#ifdef __MORPHOS__
+	if ( setjmp59(png_ptr->jmpbuf59))
+#else
     if (setjmp(png_jmpbuf(png_ptr)))
+#endif
     {
         uncreate();
         /* Free all of the memory associated with the png_ptr and info_ptr */


### PR DESCRIPTION
Update Makefile.amiga
and use shared libraries from last SDK
