### PR TITLE
Make build more GNU conformant and reproducible

### DIFF
--- a/src/Makefile.linux
+++ b/src/Makefile.linux
@@ -1,14 +1,15 @@
-CFLAGS = -O2 -Wall -Wextra -DDIR_OPENMRAC_DAT=/usr/share/openmrac/ -fno-exceptions -fPIC -std=c++20 -DNDEBUG
-LFLAGS = -lSDL2 -lGL -lopenal -ljpeg -lpng -lm -s
+prefix ?= /usr/local
+CXXFLAGS += -O2 -Wall -Wextra -DDIR_OPENMRAC_DAT=$(prefix)/share/openmrac/ -fno-exceptions -fPIC -std=c++20 -DNDEBUG
+LDFLAGS += -lSDL2 -lGL -lopenal -ljpeg -lpng -lm -s -lstdc++
 
 # Uncomment the following two lines to use MiniAL instead of OpenAL:
-#CFLAGS = -O2 -Wall -Wextra -DDIR_OPENMRAC_DAT=/usr/share/openmrac/ -DUSE_MINIAL -fno-exceptions -fPIC
-#LFLAGS = -lSDL2 -lGL -ljpeg -lpng -lm -s
+#CXXFLAGS += -O2 -Wall -Wextra -DDIR_OPENMRAC_DAT=$(prefix)/share/openmrac/ -DUSE_MINIAL -fno-exceptions -fPIC
+#LDFLAGS += -lSDL2 -lGL -ljpeg -lpng -lm -s -lstdc++
 
-CXX    = g++
-LINK   = g++
+CC ?= g++
+override LD = $(CC)
 TARGET = openmrac
-OBJS := $(shell ls *.cpp | grep -v _win32.cpp | sed 's/.cpp/.o/g' | tr '\n' ' ')
+OBJS := $(sort $(shell ls *.cpp | grep -v _win32.cpp | sed 's/.cpp/.o/g' | tr '\n' ' '))
 
 .PHONY: all clean install uninstall deb
 
@@ -18,10 +19,10 @@ clean:
 	rm -f *.o $(TARGET)
 
 %.o: %.cpp *.h shaders/*.h
-	$(CXX) -c $(CFLAGS) $<
+	$(CC) -c $(CPPFLAGS) $(CXXFLAGS) $<
 
 $(TARGET): $(OBJS)
-	$(LINK) -o $(TARGET) $(OBJS) $(LFLAGS)
+	$(LD) -o $(TARGET) $(OBJS) $(LDFLAGS)
 
 install: all uninstall
 	sudo cp openmrac /usr/bin/openmrac


### PR DESCRIPTION
Most GNU/Linux distributions' packaging build toolchains are centered around Makefiles that follow GNU Makefile conventions, such as supporting staged installs (via the DESTDIR variable), for example, besides honoring {CPP,C,LD}FLAGS.

Other concern modern distributions have regard reproducible builds [1]. To make a build reproducible, the build system needs to be made entirely deterministic. For example, the current date and time must not be recorded and output must always be written on the same order.

This patch makes the OpenMRac Linux build more GNU conformant (enough for the Debian packaging build toolchain) and deterministic, by appending to *FLAGS instead of overwriting them in the former case, and by sorting he object file list in the latter.

[1] https://reproducible-builds.org/