### PR TITLE
Add Keywords field to XDG Desktop Entry file

### DIFF
--- a/src/openmrac.desktop
+++ b/src/openmrac.desktop
@@ -2,6 +2,7 @@
 Categories=Application;Game;
 Exec=openmrac
 Icon=/usr/share/pixmaps/openmrac.ico
+Keywords=3D;multiplayer;car;racing;split-screen;
 Name=OpenMRac
 Terminal=false
 Type=Application


### PR DESCRIPTION
Desktop environments compatible with Freedesktop.org's XDG specifications use the 'Keywords' field to improve the ability to find apps by typing in related words.

This patch includes keywords related to OpenMRac, to enhance its discoverability after installation.